### PR TITLE
Support Laravel 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,17 @@ php:
  - 7.3
  - 7.4
 
-env: 
-  - ILLUMINATE_VERSION=^7.0  
+env:
+  - ILLUMINATE_VERSION=^7.0
+  - ILLUMINATE_VERSION=^8.0
+
+jobs:
+  exclude:
+    - php: 7.2
+      env: ILLUMINATE_VERSION=^8.0
 
 before_install:
+  - if [ $ILLUMINATE_VERSION == "^8.0" ]; then composer require "laravel/legacy-factories" --no-update; fi
   - composer require "illuminate/database:${ILLUMINATE_VERSION}" --no-update
 install:
  - composer update --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "illuminate/database": "^7.0",
-        "vinkla/hashids": "^8.0"
+        "illuminate/database": "^7.0|^8.0",
+        "vinkla/hashids": "^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0",
-        "orchestra/database": "^5.0",
+        "orchestra/testbench": "^5.0|^6.0",
+        "orchestra/database": "^5.0|^6.x-dev",
         "phpunit/phpunit": "^8.4|^9.0"
     },
     "autoload": {


### PR DESCRIPTION
Laravel 8.0 changed Factories (https://laravel.com/docs/8.x/upgrade#model-factories) 
Included https://github.com/laravel/legacy-factories therefor, this is only needed for testing

Closes #12 