### PR TITLE
Add useful idToHashid method and hashid accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ the desired settings.
 // Generating the model hashid based on its key
 $item->hashid();
 
+// Accessing the model hashid as a property based on its key
+$item->hashid;
+
+// Add hashid to the serialized model
+return $item->append('hashid')->toJson();
+
+// Or add it by default in the model
+
+use Mtvs\EloquentHashids\HasHashid;
+
+class Item extends Model
+{
+    use HasHashid;
+    
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appends = ['hashid'];
+}
+
 // Finding a model based on the provided hashid or
 // returning null on failure
 Item::findByHashid($hashid);
@@ -66,6 +88,9 @@ Item::findByHashidOrFail($hashid);
 
 // Decoding a hashid to the integer id 
 $item->hashidToId($hashid);
+
+// Encoding an id to the hashid
+$item->idToHashid($id);
 
 // Getting the name of the hashid connection
 $item->getHashidsConnection();

--- a/README.md
+++ b/README.md
@@ -56,14 +56,35 @@ the desired settings.
 // Generating the model hashid based on its key
 $item->hashid();
 
-// Accessing the model hashid as a property based on its key
+// Equivalent to the above but with the attribute style
 $item->hashid;
 
-// Add hashid to the serialized model
-return $item->append('hashid')->toJson();
+// Finding a model based on the provided hashid or
+// returning null on failure
+Item::findByHashid($hashid);
 
-// Or add it by default in the model
+// Finding a model based on the provided hashid or
+// throwing a ModelNotFoundException on failure
+Item::findByHashidOrFail($hashid);
 
+// Decoding a hashid to its equivalent id 
+$item->hashidToId($hashid);
+
+// Encoding an id to its equivalent hashid
+$item->idToHashid($id);
+
+// Getting the name of the hashid connection
+$item->getHashidsConnection();
+
+```
+
+### Add the hashid to the serialized model
+
+Set it as default:
+
+```php
+
+use Illuminate\Database\Eloquent\Model;
 use Mtvs\EloquentHashids\HasHashid;
 
 class Item extends Model
@@ -78,24 +99,12 @@ class Item extends Model
     protected $appends = ['hashid'];
 }
 
-// Finding a model based on the provided hashid or
-// returning null on failure
-Item::findByHashid($hashid);
-
-// Finding a model based on the provided hashid or
-// throwing a ModelNotFoundException on failure
-Item::findByHashidOrFail($hashid);
-
-// Decoding a hashid to the integer id 
-$item->hashidToId($hashid);
-
-// Encoding an id to the hashid
-$item->idToHashid($id);
-
-// Getting the name of the hashid connection
-$item->getHashidsConnection();
-
 ```
+
+or specify it specificly:
+
+`return $item->append('hashid')->toJson();`
+
 
 ### Route Binding
 

--- a/src/HasHashid.php
+++ b/src/HasHashid.php
@@ -21,8 +21,7 @@ trait HasHashid
 
 	public function hashid()
 	{
-		return Hashids::connection($this->getHashidsConnection())
-			->encode($this->getKey());
+		return $this->idToHashid($this->getKey());
 	}
 
 	/**
@@ -35,6 +34,18 @@ trait HasHashid
 	{
 		return @Hashids::connection($this->getHashidsConnection())
 			->decode($hashid)[0];
+	}
+
+	/**
+	 * Encode an id to hashid
+	 *
+	 * @param string $id
+	 * @return string|null
+	 */
+	public function idToHashid($id)
+	{
+		return @Hashids::connection($this->getHashidsConnection())
+			->encode($id);
 	}
 
 	public function getHashidsConnection()

--- a/src/HasHashid.php
+++ b/src/HasHashid.php
@@ -37,7 +37,7 @@ trait HasHashid
 	}
 
 	/**
-	 * Encode an id to hashid
+	 * Encode an id to its equivalent hashid
 	 *
 	 * @param string $id
 	 * @return string|null
@@ -54,7 +54,7 @@ trait HasHashid
 	}
 
 	protected function getHashidAttribute()
-        {
-            return $this->hashid();
-        }
+    {
+        return $this->hashid();
+    }
 }

--- a/src/HasHashid.php
+++ b/src/HasHashid.php
@@ -52,4 +52,9 @@ trait HasHashid
 	{
 		return config('hashids.default');
 	}
+
+	protected function getHashidAttribute()
+        {
+            return $this->hashid();
+        }
 }

--- a/tests/HasHashidTest.php
+++ b/tests/HasHashidTest.php
@@ -14,14 +14,41 @@ class HasHashidTest extends TestCase
 	/**
 	 * @test
 	 */
-	public function it_can_generate_the_hashid()
+	public function it_can_encode_the_model_id_to_its_hashid()
 	{
 		$item = factory(Item::class)->create();
 
 		$hashid = Hashids::encode($item->getKey());
 
 		$this->assertEquals($hashid, $item->hashid());
+		$this->assertEquals($hashid, $item->hashid);
 	}
+
+	/**
+	 * @test
+	 */
+	public function it_can_append_its_hashid_to_its_serialized_version()
+	{
+		$item = factory(Item::class)->create();
+
+		$hashid = Hashids::encode($item->getKey());
+
+		$serialized = json_decode($item->append('hashid')->toJson());
+
+		$this->assertEquals($hashid, $serialized->hashid);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_can_enceode_an_arbitrary_id_to_its_hashid()
+	{
+		$item = new Item();
+
+		$hashid = Hashids::encode(123);
+
+		$this->assertEquals($hashid, $item->idToHashid(123));
+	}	
 
 	/**
 	 * @test


### PR DESCRIPTION
A new `$item->idToHashid($id)` method allows you to generate a models hashid for any given id.
Adding the `getHashidAttribute()` method allows you to access the `hashid` property and add it to the JSON or toArray output.