### PR TITLE
Resolve issue where explicit key in route breaks routing

### DIFF
--- a/src/HashidRouting.php
+++ b/src/HashidRouting.php
@@ -9,7 +9,7 @@ trait HashidRouting
 	 */
 	public function resolveRouteBinding($value, $field = null)
 	{
-		if ($field) {
+		if ($field && $field !== 'hashid') {
 			return parent::resolveRouteBinding($value, $field);
 		}
 


### PR DESCRIPTION
Specifying `hashid` as an explicit key in the route file breaks routing using `HashidRouting`.

# Steps to reproduce

1. Add `use HashidRouting` on a model
2. Explicitly name the key in your route definition `Route::get('/entity/{entity:hashid}', 'MyController');`
3. Attempt to access route, and note that an error is received as Laravel's own routing is invoked:
```Illuminate \ Database \ QueryException
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'hashid' in 'where clause'
select * from `entities` where `hashid` = dWNDq limit 1
```
4. The issue is that `HashidRouting` does not interfere if a field is specifically named, even if that field is `hashid`