### PR TITLE
Support child route binding

### DIFF
--- a/src/HashidRouting.php
+++ b/src/HashidRouting.php
@@ -2,6 +2,9 @@
 
 namespace Mtvs\EloquentHashids;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
 trait HashidRouting
 {
 	/**
@@ -15,6 +18,25 @@ trait HashidRouting
 
 		return $this->findByHashid($value);
 	}
+
+	/**
+    * @see parent
+    */
+    public function resolveChildRouteBinding($childType, $value, $field)
+    {
+        $relationship = $this->{Str::plural(Str::camel($childType))}();
+
+		if(!($relationship instanceof Model)){
+			$relationship = $relationship->getRelated();
+		}
+
+        if (null === $field && \in_array(HashidRouting::class, class_uses_recursive($relationship), true)) {
+			$value = $relationship->hashidToId($value);
+			$field = $relationship->getKeyName();
+        }
+
+        return parent::resolveChildRouteBinding($childType, $value, $field);
+    }
 
 	/**
 	 * @see parent

--- a/tests/HashidRoutingTest.php
+++ b/tests/HashidRoutingTest.php
@@ -5,6 +5,7 @@ namespace Mtvs\EloquentHashids\Tests;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Routing\Middleware\SubstituteBindings;
+use Mtvs\EloquentHashids\Tests\Models\Child;
 use Mtvs\EloquentHashids\Tests\Models\Item;
 use Vinkla\Hashids\Facades\Hashids;
 
@@ -50,5 +51,35 @@ class HashidRoutingTest extends TestCase
 		$hashid = Hashids::encode($item->id);
 
 		$this->assertEquals($hashid, $item->getRouteKey());
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_can_resolve_hashid_of_child_routing_binding(){
+		$givenChild = factory(Child::class)->create();
+		$givenItem = $givenChild->item;
+
+		Route::get('/items/{item}/children/{child}', function (Item $item, Child $child) use ($givenChild, $givenItem) {
+			$this->assertEquals($givenItem->id, $item->id);
+			$this->assertEquals($givenChild->id, $child->id);
+		})->middleware(SubstituteBindings::class)->scopeBindings();
+
+		$this->get("/items/{$givenItem->getRouteKey()}/children/{$givenChild->getRouteKey()}")->assertOk();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_can_resolve_specifying_field_of_child_routing_binding(){
+		$givenChild = factory(Child::class)->create();
+		$givenItem = $givenChild->item;
+
+		Route::get('/items/{item}/children/{child:id}', function (Item $item, Child $child) use ($givenChild, $givenItem) {
+			$this->assertEquals($givenItem->id, $item->id);
+			$this->assertEquals($givenChild->id, $child->id);
+		})->middleware(SubstituteBindings::class)->scopeBindings();
+
+		$this->get("/items/{$givenItem->getRouteKey()}/children/{$givenChild->id}")->assertOk();
 	}
 }

--- a/tests/Models/Child.php
+++ b/tests/Models/Child.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Mtvs\EloquentHashids\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Mtvs\EloquentHashids\HasHashid;
+use Mtvs\EloquentHashids\HashidRouting;
+
+class Child extends Model
+{
+	use HasHashid;
+	use HashidRouting;
+
+	protected $guarded = [];
+
+    public function Item(){
+        return $this->belongsTo(Item::class);
+    }
+}

--- a/tests/Models/Item.php
+++ b/tests/Models/Item.php
@@ -2,6 +2,7 @@
 
 namespace Mtvs\EloquentHashids\Tests\Models;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Mtvs\EloquentHashids\HasHashid;
 use Mtvs\EloquentHashids\HashidRouting;
@@ -12,4 +13,9 @@ class Item extends Model
 	use HashidRouting;
 
 	protected $guarded = [];
+
+	public function children()
+	{
+		return $this->hasMany(Child::class);
+	}
 }

--- a/tests/database/factories/ChildFactory.php
+++ b/tests/database/factories/ChildFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+use Faker\Generator;
+use Mtvs\EloquentHashids\Tests\Models\Child;
+use Mtvs\EloquentHashids\Tests\Models\Item;
+
+$factory->define(Child::class, function (Generator $faker) {
+	return [
+		'item_id' => factory(Item::class)->create()->id,
+	];
+});

--- a/tests/database/migrations/2019_07_10_222200_create_children_table.php
+++ b/tests/database/migrations/2019_07_10_222200_create_children_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateChildrenTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('children', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreignId('item_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('children');
+    }
+}


### PR DESCRIPTION
```php
Route::get('/users/{user}/posts/{post}', function (User $user, Post $post) {
    return $post;
})->scopeBindings();
```

This PR will support the scopeBindings method above